### PR TITLE
Add support for expressions instead of columns.

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -320,6 +320,9 @@ func Unmarshal(s Scannable, dst interface{}) error {
 		}
 		field := getFieldColumn(t.Field(i), true)
 		if field == "" {
+			field = getFieldExpression(t.Field(i))
+		}
+		if field == "" {
 			continue
 		}
 


### PR DESCRIPTION
Add methods that will allow you to use the `sql_expression` tag instead
of the `sql_column` tag, to map struct fields to things like COUNT(*)
instead of to columns.

This is clearly due for a refactor.