### PR TITLE
When querying in test, include expressions.

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -357,7 +357,8 @@ func TestUnmarshal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	row := db.QueryRow("SELECT * FROM test_types;")
+	fields, _ = GetQuotedFieldsAndExpressions(dummy)
+	row := db.QueryRow("SELECT " + QueryList(fields) + " FROM test_types;")
 	err = Unmarshal(row, &expectation)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
We used `*` in a select query, but were unmarshalling it to a type that
had a property defined by an expression. This caused the unmarshalling
code to complain, because the result used to populate that property
wasn't available, so we had a mismatch and it didn't know what to do.

The solution was to use GetQuotedFieldsAndExpressions to query for the
fields we want, which is what we should have been doing in the first
place.